### PR TITLE
Update Shopify CLI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "info": "shopify app info"
   },
   "dependencies": {
-    "@shopify/app": "3.50.0",
-    "@shopify/cli": "3.50.0"
+    "@shopify/app": "3.48.2",
+    "@shopify/cli": "3.48.2"
   },
   "author": "Remy Wang",
   "private": true,


### PR DESCRIPTION
Shopify CLI version `3.50.0` doesn't work. The workable version is `3.48.2`

Related issue: [#2998](https://github.com/Shopify/cli/issues/2998)